### PR TITLE
Fix check for Traversable in TranslatorAwareTreeRouteStack->factory()

### DIFF
--- a/src/Router/TranslatorAwareTreeRouteStack.php
+++ b/src/Router/TranslatorAwareTreeRouteStack.php
@@ -7,6 +7,7 @@
 
 namespace Zend\Mvc\I18n\Router;
 
+use Traversable;
 use Zend\I18n\Translator\TranslatorInterface as Translator;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Router\Exception;


### PR DESCRIPTION
Previously, this always returned false. See https://3v4l.org/YgpKg
This was detected by etsy/phan, and may or may not affect real code. iterator_to_array() preserves keys.
Some classes implement Traversable but not ArrayAccess, so I'm leaving this check in.