### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ two components.
 $ composer require zendframework/zend-mvc-i18n
 ```
 
-Assuming you are using the [component installer](https://zendframework.github.io/zend-component-installer],
+Assuming you are using the [component installer](https://zendframework.github.io/zend-component-installer),
 doing so will enable the component in your application, allowing you to
 immediately start developing console applications via your MVC. If you are not,
 please read the [introduction](https://zendframework.github.io/zend-mvc-i18n/intro/)


### PR DESCRIPTION
Fixed a syntax issue in the link to the zend-component-installer.