### PR TITLE
Link to zend-config-aggregator instead of deprected expressive-config-manager

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -54,7 +54,7 @@ files:
 > ```
 >
 > to your `config/config.php` class, assuming you are already using
-> [expressive-config-manager](https://github.com/mtymek/expressive-config-manager).
+> [zend-config-aggregator](https://docs.zendframework.com/zend-config-aggregator/).
 >
 > If you are not, add a new global `config/autoload/` file with the following contents:
 >


### PR DESCRIPTION
Since version 2 of expressive we are using zend-config-aggregator.

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
